### PR TITLE
Do not auto-increment dependent packages to the latest version published on npm. In more details:

### DIFF
--- a/lib/feedsme/index.js
+++ b/lib/feedsme/index.js
@@ -246,34 +246,9 @@ Feedsme.prototype.increment = function inc(payload, head) {
   // which would mess up our whole system here
   //
   const latestHead = this._latestHead(head);
-  if (!latest.version || semver.lte(latest.version, latestHead)) {
-    version = semver.inc(latestHead, 'prerelease');
-    action = 'publish';
-  }
 
-  // Protect regular publishes that dont need the rest of this
-  if (version === latest.version) return { payload, action };
-
-  latest.version = version;
-  // Unique identifier set in publish in npm-registry-client this should change
-  // but we can keep the tarballs the same since the content doesnt change. In
-  // the future we may want to make this more complete to be a 100% "proper" publish
-  latest._id = `${name}@${version}`;
-  payload.version = version;
-  // kill previous versions so we dont grow out of hand
-  payload.versions = {};
-  payload.versions[version] = latest;
-  payload['dist-tags'].latest = version;
-
-  const tar = name + '-' + version + '.tgz';
-  //
-  // Modify attachments since carpenterd uses this as well based on version
-  //
-  payload._attachments = payload._attachments || {};
-  const key = Object.keys(payload._attachments)[0];
-  if (!payload._attachments[prevTar]) prevTar = key;
-  payload._attachments[tar] = payload._attachments[prevTar] || {};
-  delete payload._attachments[prevTar];
+  version = semver.inc(latestHead, 'prerelease');
+  action = 'publish';
 
   return { payload, action };
 };


### PR DESCRIPTION
### Context 

Latest in npm
  `@ux/parent-package@6.0.0`
  `@ux/dependent-package@6.0.0`

Currently in PROD
  `@ux/parent-package@5.4.0`
  `@ux/dependent-package@5.0.1-12`

### Current behavior

`@ux/parent-package@5.5.0`
  PROMOTE to PROD
  causes PROMOTE
`@ux/dependent-package@6.0.0`

### Proposed behavior

`@ux/parent-package@5.5.0`
  PROMOTE to PROD
  causes CREATE & PROMOTE
`@ux/dependent-package@5.0.1-13`